### PR TITLE
added git-repo option for monoreps needing more than one gh-pages

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,9 @@ var commandLineArgs = require('command-line-args');
 var workingDir = process.cwd();
 
 var options = commandLineArgs([
-  {name: 'dist', defaultValue: 'dist'}
+  {name: 'dist', defaultValue: 'dist'},
+  {name: 'git-repo', defaultValue: process.env.GIT_REMOTE_URL},
 ]);
 
 require('child_process')
-  .spawn(__dirname + '/release.sh', [workingDir, options.dist], {stdio: 'inherit'});
+  .spawn(__dirname + '/release.sh', [workingDir, options.dist, options['git-repo']], {stdio: 'inherit'});

--- a/release.sh
+++ b/release.sh
@@ -2,7 +2,7 @@
 
 cd /tmp
 rm -rf gh-pages
-git clone $GIT_REMOTE_URL gh-pages
+git clone $3 gh-pages
 cd gh-pages
 git checkout --orphan gh-pages
 shopt -s extglob dotglob


### PR DESCRIPTION
this could be useful when it's discovered that a project in a monorepo is overwriting the gh pages of another project in the same repo :)
 